### PR TITLE
Fix line mutation

### DIFF
--- a/lib/img2zpl/image.rb
+++ b/lib/img2zpl/image.rb
@@ -7,7 +7,7 @@ module Img2Zpl
 		def to_zpl(black_threshold: 0.5, invert: false, compress: true)
 			bytes_per_row = (width % 8).positive? ? (width / 8) + 1 : (width / 8)
 			byte_count = bytes_per_row * height
-			data, line, previous_line, byte = Array.new(4, +"")
+			data, line, previous_line, byte = Array.new(4) { +"" }
 
 			get_pixels.each do |row|
 				row.each_with_index do |column, i|


### PR DESCRIPTION
`Array.new(4, +"")` - Shared Mutation Risk

You probably want to explicitly create different rows via +"", but not the same object four times