### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### v1.0.3 (next)
 
-* Your contribution here
+[#11](https://github.com/mtking2/img2zpl/pull/11): Reduce gem size by excluding test files - [@yuri-zubov](https://github.com/yuri-zubov)
 
 ### v1.0.2 (2025/05/22)
 

--- a/img2zpl.gemspec
+++ b/img2zpl.gemspec
@@ -12,7 +12,11 @@ Gem::Specification.new do |spec|
 	spec.homepage = "https://github.com/mtking2/img2zpl"
 	spec.license = "MIT"
 
-	spec.files = `git ls-files`.split($/)
+	spec.files = `git ls-files lib`.split($/) + [
+    "CHANGELOG.md",
+    "LICENSE.txt",
+    "README.md"
+  ]
 	spec.require_paths = ["lib"]
 
 	spec.add_dependency "mini_magick", ">= 4.9"


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar.gz

$ git switch reduce-gem-size

$ gem build -o after.tar.gz

$ du -sh before after
 32K	before.tar.gz
 8.0K	after.tar.gz
 ```
 
|          | Before | After | Saved               |
|----------|--------|-------|---------------------|
| **Size** | 32K    | 8.0K  | **-24K (⏷ -75.00%)** |

###  whitch files was deleted?

```diff
-├── .github/
-│   └── workflows/lint-and-test.yml
-├── .gitignore
-├── .rspec
-├── .rubocop.yml
-├── .ruby-version
-├── bin/
-│   ├── bundle
-│   ├── console
-│   ├── rspec
-│   ├── rubocop
-│   └── setup
 ├── CHANGELOG.md
-├── CONTRIBUTING.md
-├── Gemfile
-├── img2zpl.gemspec
 ├── lib/
 │   ├── img2zpl/
 │   │   ├── image.rb
 │   │   └── version.rb
 │   └── img2zpl.rb
 ├── LICENSE
-├── Rakefile
 ├── README.md
-└── spec/
-    ├── fixtures/default.jpg
-    ├── img2zpl/image_spec.rb
-    └── spec_helper.rb

```
